### PR TITLE
fix: disabling cfp + sorting event logic

### DIFF
--- a/src/views/CFPView.vue
+++ b/src/views/CFPView.vue
@@ -50,7 +50,20 @@
                       {{ getDate(item.StartingDate) }}
                     </template>
                     <template v-slot:[`item.custom`]="{ item }">
-                      <a :href="item.CFP.Link" target="_black">Apply now</a>
+                      <a
+                        v-if="new Date(item.CFP.LastDate) >= new Date().setHours(0,0,0,0)"
+                        color="red"
+                        style="font-size: 14px; text-decoration: underline"
+                        :href="item.CFP.Link"
+                        target="_black"
+                        >Apply now
+                     </a>
+                      <a
+                        v-else
+                        class="disabled"
+                      >Applications closed
+                      </a>
+                      <!-- <a :href="item.CFP.Link" target="_black">Apply now</a> -->
                     </template>
 
                     <template v-slot:[`item.deadline`]="{ item }">

--- a/src/views/DevFestCommunityPage.vue
+++ b/src/views/DevFestCommunityPage.vue
@@ -52,7 +52,7 @@
               <div  v-if="eventData.CFP.Status==1" class="mt-5">
               <p class="mb-0"><b>Call For Presentations</b></p>
               <a
-                v-if="Date(eventData.CFP.LastDate) >= new Date()"
+                v-if="new Date(eventData.CFP.LastDate) >= new Date().setHours(0,0,0,0)"
                 color="red"
                 style="font-size: 17px; text-decoration: underline"
                 :href="eventData.CFP.Link"

--- a/src/views/FindAnEvent.vue
+++ b/src/views/FindAnEvent.vue
@@ -43,9 +43,9 @@ export default {
   }),
   mounted() {
     const PassedEvents = devfestData.filter((i) => {
-      return new Date(i.StartingDate) - new Date() < 0;
+      return new Date(i.StartingDate) - new Date().setHours(0,0,0,0) < 0;
     });
-    const ToBeHeldEvents = devfestData.filter((i) => { return new Date(i.StartingDate) - new Date() >= 0; });
+    const ToBeHeldEvents = devfestData.filter((i) => { return new Date(i.StartingDate) - new Date().setHours(0,0,0,0) >= 0; });
     const sortedToBeHeldEvents = ToBeHeldEvents.sort((a, b) => {
       return new Date(a.StartingDate) - new Date(b.StartingDate);
     });


### PR DESCRIPTION
This PR enables diabling logic for CFP page.
Also it rectifies the previous sorting logic, ideally it should show the nearest/today's event on first view, but right now it is not. Issue was we were not setting the datetime to midnight